### PR TITLE
Convert engine to ES modules

### DIFF
--- a/indexGame001.html
+++ b/indexGame001.html
@@ -2,46 +2,7 @@
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <script type="text/javascript" src="scripts/core/lib/keypress.js"></script>
-    <script type="text/javascript" src="scripts/core/util/utils.js"></script>
-    <script type="text/javascript" src="scripts/core/logger.js"></script>
-    <script type="text/javascript" src="scripts/core/constants.js"></script>
-    <script type="text/javascript" src="scripts/core/configuration.js"></script>
-    <script type="text/javascript" src="scripts/core/input/inputSource.js"></script>
-    <script type="text/javascript" src="scripts/core/input/inputManager.js"></script>
-    <script type="text/javascript" src="scripts/core/input/keyboardSource.js"></script>
-    <script type="text/javascript" src="scripts/core/manager/statusManager.js"></script>
-    <script type="text/javascript" src="scripts/core/manager/menu.js"></script>
-    <script type="text/javascript" src="scripts/core/manager/ingame/scenarioDefinition.js"></script>
-    <script type="text/javascript" src="scripts/core/manager/ingame/renderingView.js"></script>
-    <script type="text/javascript" src="scripts/core/manager/ingame/ingame.js"></script>
-    <script type="text/javascript" src="scripts/core/userInterface.js"></script>
-    <script type="text/javascript" src="scripts/core/sprite/spriteAction.js"></script>
-    <script type="text/javascript" src="scripts/core/sprite/spriteData.js"></script>
-    <script type="text/javascript" src="scripts/core/actor/actor.js"></script>
-    <script type="text/javascript" src="scripts/core/actor/assetActor.js"></script>
-    <script type="text/javascript" src="scripts/core/actor/player.js"></script>
-    <script type="text/javascript" src="scripts/core/game.js"></script>
-
-    <script type="text/javascript" src="scripts/custom/customConstants.js"></script>
-    <script type="text/javascript" src="scripts/custom/customConfig.js"></script>
-    <script type="text/javascript" src="scripts/custom/SpriteDataList.js"></script>
-
-    <script type="text/javascript" src="scripts/custom/scenario/testScenario001.js"></script>
-    <script type="text/javascript" src="scripts/custom/scenario/testScenario002.js"></script>
-    <script type="text/javascript" src="scripts/custom/scenario/testScenario003.js"></script>
-    <script type="text/javascript" src="scripts/custom/scenario/testScenario004.js"></script>
-    <script type="text/javascript" src="scripts/custom/scenario/testScenario005.js"></script>
-    <script type="text/javascript" src="scripts/custom/scenario/testScenarioMultiplayer.js"></script>
-
-    <script type="text/javascript" src="scripts/custom/game001/gameMenu.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/gameRenderingView.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/gameSM.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/gamePlayer.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/enemyBear.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/bomb.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/bullet.js"></script>
-    <script type="text/javascript" src="scripts/custom/game001/main.js"></script>
+    <script type="module" src="scripts/custom/game001/main.js"></script>
 </head>
 <body>
 

--- a/scripts/core/actor/actor.js
+++ b/scripts/core/actor/actor.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class Actor {
+export default class Actor {
     /**
      * Constructor
      * @param context contexto del juego

--- a/scripts/core/actor/assetActor.js
+++ b/scripts/core/actor/assetActor.js
@@ -1,9 +1,12 @@
+
+import Actor from './actor.js';
+import { CONS } from '../constants.js';
 'use strict';
 
 /**
  * Clase que gestiona a un Actor basado en un sprite
  */
-class AssetActor extends Actor {
+export default class AssetActor extends Actor {
 
     /**
      * Constructor

--- a/scripts/core/actor/player.js
+++ b/scripts/core/actor/player.js
@@ -1,3 +1,6 @@
+
+import AssetActor from './assetActor.js';
+import { CONS } from '../constants.js';
 'use strict';
 
 /**
@@ -6,7 +9,7 @@
  * Al final de la clase se detallan los métodos a sobreescribir para implementar la lógica del jugador.
  * Si se sobreescribe cualquier otro método, se debe llamar siempre al método padre, o replicar el código para no romper su funcionamiento.
  */
-class Player extends AssetActor {
+export default class Player extends AssetActor {
     /**
      * Constructor
      * @param context contexto del juego

--- a/scripts/core/actor/playerGravity.js
+++ b/scripts/core/actor/playerGravity.js
@@ -1,9 +1,11 @@
+
+import Player from './player.js';
 'use strict';
 
 /**
  * Clase abstracta que gestiona a un Jugador para escenarios con gravedad.
  */
-class PlayerGravity extends Player {
+export default class PlayerGravity extends Player {
     /**
      * Constructor
      * @param context contexto del juego

--- a/scripts/core/configuration.js
+++ b/scripts/core/configuration.js
@@ -1,9 +1,11 @@
+
+import { CONS } from './constants.js';
 'use strict';
 
 /**
  * Configuración del Juego por defecto
  */
-var CONFIG =
+export const CONFIG =
     {
         /**
          * Ancho de pantalla

--- a/scripts/core/constants.js
+++ b/scripts/core/constants.js
@@ -3,7 +3,7 @@
 /**
  * Definición de constantes para el juego
  */
-var CONS =
+export const CONS =
     {
         // Niveles de log
         logLevel: {

--- a/scripts/core/game.js
+++ b/scripts/core/game.js
@@ -1,9 +1,13 @@
+
+import { CONFIG } from './configuration.js';
+import { LOGGER } from './logger.js';
+import InputManager from './input/inputManager.js';
 'use strict';
 
 /**
  * Clase principal que gestiona todo el juego.
  */
-class Game {
+export default class Game {
     /**
      * Constructor del juego
      * @param layers cantidad de capas de dibujado que tendrá el juego

--- a/scripts/core/input/inputManager.js
+++ b/scripts/core/input/inputManager.js
@@ -1,9 +1,15 @@
+
+import { CONFIG } from '../configuration.js';
+import { CONS } from '../constants.js';
+import { LOGGER } from '../logger.js';
+import { Utils } from '../util/utils.js';
+import KeyboardSource from './keyboardSource.js';
 'use strict';
 
 /**
  * Clase gestora para las entradas del juego.
  */
-class InputManager {
+export default class InputManager {
     /**
      * Constructor
      * @param inputSource clase gestora del origen de la entrada (subclase de inputSource)

--- a/scripts/core/input/inputSource.js
+++ b/scripts/core/input/inputSource.js
@@ -1,3 +1,5 @@
+
+import { CONS } from '../constants.js';
 'use strict';
 
 /**
@@ -6,7 +8,7 @@
  * Todas las subclases deben sobreescribir el metodo "getType", que ha de devolver
  * un valor de CONS.inputType, y opcionalmente el metodo init, que inicializa la clase
  */
-class InputSource {
+export default class InputSource {
     constructor() {
         this._inited = false;
     }

--- a/scripts/core/input/keyboardSource.js
+++ b/scripts/core/input/keyboardSource.js
@@ -1,9 +1,15 @@
+
+import keypress from '../lib/keypress.js';
+import { CONFIG } from '../configuration.js';
+import { LOGGER } from '../logger.js';
+import { CONS } from '../constants.js';
+import InputSource from './inputSource.js';
 'use strict';
 
-class KeyboardSource extends InputSource {
+export default class KeyboardSource extends InputSource {
     constructor(manager) {
         super(manager);
-        this._listener = new window.keypress.Listener();
+        this._listener = new keypress.Listener();
     }
 
     init() {

--- a/scripts/core/lib/keypress.js
+++ b/scripts/core/lib/keypress.js
@@ -1133,10 +1133,8 @@ Combo options available and their defaults:
         define([], function () {
             return keypress;
         });
-    } else if (typeof exports !== "undefined" && exports !== null) {
-        exports.keypress = keypress;
-    } else {
-        window.keypress = keypress;
     }
+
+export default keypress;
 
 }).call(this);

--- a/scripts/core/logger.js
+++ b/scripts/core/logger.js
@@ -1,9 +1,12 @@
+
+import { CONS } from './constants.js';
+import { CONFIG } from './configuration.js';
 'use strict';
 
 /**
  * Clase para escribir trazas de log.
  */
-class Log {
+export class Log {
 
     constructor() {
     }
@@ -99,4 +102,4 @@ class Log {
  * INSTANCIA DEL LOGGER. Es necesario que exista.
  * Se puede sobreescribir esta propiedad para usar un Logger propio.
  */
-var LOGGER = new Log();
+export const LOGGER = new Log();

--- a/scripts/core/manager/ingame/ingame.js
+++ b/scripts/core/manager/ingame/ingame.js
@@ -1,6 +1,12 @@
+
+import StatusManager from '../statusManager.js';
+import RenderingView from './renderingView.js';
+import ScenarioDefinition from './scenarioDefinition.js';
+import { Utils } from '../../util/utils.js';
+import { CONS } from '../../constants.js';
 'use strict';
 
-class InGame extends StatusManager {
+export default class InGame extends StatusManager {
     constructor(context) {
         super(context);
         this._actorList = Array();

--- a/scripts/core/manager/ingame/renderingView.js
+++ b/scripts/core/manager/ingame/renderingView.js
@@ -1,6 +1,8 @@
+
+import { Utils } from '../../util/utils.js';
 'use strict';
 
-class RenderingView {
+export default class RenderingView {
     constructor(statusManager, scenarioDefinition, actor, x, y, width, height, drawableActors) {
         this._manager = statusManager;
         this._scenario = scenarioDefinition;

--- a/scripts/core/manager/ingame/scenarioDefinition.js
+++ b/scripts/core/manager/ingame/scenarioDefinition.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class ScenarioDefinition {
+export default class ScenarioDefinition {
     constructor(definition, cellwidth, cellheight, isDynamic) {
         this._def = definition;
         this.cellwidth = cellwidth;

--- a/scripts/core/manager/menu.js
+++ b/scripts/core/manager/menu.js
@@ -1,9 +1,15 @@
+
+import StatusManager from './statusManager.js';
+import { Utils } from '../util/utils.js';
+import { CONFIG } from '../configuration.js';
+import { CONS } from '../constants.js';
+import { LOGGER } from '../logger.js';
 'use strict';
 
 /**
  * Clase para gestionar el menú principal
  */
-class Menu extends StatusManager {
+export default class Menu extends StatusManager {
     /**
      * Constructor
      * @param context instancia de la clase game (contexto del juego)

--- a/scripts/core/manager/statusManager.js
+++ b/scripts/core/manager/statusManager.js
@@ -4,7 +4,7 @@
  * Clase base para gestionar un estado del juego (CONS.status).
  * Todas las subclases han de sobreescribir los métodos act, draw, start, pause, resume, exit.
  */
-class StatusManager {
+export default class StatusManager {
     /**
      * @param context instancia de la clase game (contexto del juego)
      */

--- a/scripts/core/sprite/spriteAction.js
+++ b/scripts/core/sprite/spriteAction.js
@@ -3,7 +3,7 @@
 /**
  * Clase que define una accion de un sprite, almacenando información de todos sus frames
  */
-class SpriteAction {
+export default class SpriteAction {
     /**
      * Constructor
      * @param actionId: id de la acción

--- a/scripts/core/sprite/spriteData.js
+++ b/scripts/core/sprite/spriteData.js
@@ -1,10 +1,12 @@
+
+import SpriteAction from './spriteAction.js';
 'use strict';
 
 /**
  * Clase para gestionar una imagen sprite.
  *
  */
-class SpriteData {
+export default class SpriteData {
     /**
      * Constructor
      * @param imageUrl: url de la imagen con los sprites

--- a/scripts/core/userInterface.js
+++ b/scripts/core/userInterface.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class userInterface {
+export default class userInterface {
     constructor(context) {
         this._ctx = context;
     }

--- a/scripts/core/util/utils.js
+++ b/scripts/core/util/utils.js
@@ -3,7 +3,7 @@
 /**
  * Agrupación de métodos útiles varios
  */
-var Utils = {
+export const Utils = {
     /**
      *  Genera un identificador único
      */

--- a/scripts/custom/SpriteDataList.js
+++ b/scripts/custom/SpriteDataList.js
@@ -1,9 +1,12 @@
+
+import SpriteData from '../core/sprite/spriteData.js';
+import { CONS } from '../core/constants.js';
 'use strict';
 
 /**
  * LISTADO DE DEFINICIONES DE LOS SPRITES EXISTENTES
  */
-var SPRITES = Array();
+export const SPRITES = Array();
 
 SPRITES[CONS.sprites.PRINCE] = new SpriteData('img/personatges_conYsin_pistola.png', 32, 32, function () {
     SPRITES[CONS.sprites.PRINCE].addActionData(CONS.spriteAction.QUIET_D, 0, 1, 1, 1, false);

--- a/scripts/custom/customConfig.js
+++ b/scripts/custom/customConfig.js
@@ -1,3 +1,7 @@
+import { CONFIG } from '../core/configuration.js';
+import { LOGGER } from '../core/logger.js';
+import { CONS } from '../core/constants.js';
+
 CONFIG.SCREEN_WIDTH = 1000;
 CONFIG.SCREEN_HEIGHT = 700;
 

--- a/scripts/custom/customConstants.js
+++ b/scripts/custom/customConstants.js
@@ -1,3 +1,5 @@
+import { CONS } from '../core/constants.js';
+
 /**
  *
  */

--- a/scripts/custom/game001/bomb.js
+++ b/scripts/custom/game001/bomb.js
@@ -1,6 +1,10 @@
+
+import AssetActor from '../../core/actor/assetActor.js';
+import { CONS } from '../../core/constants.js';
+import { SPRITES } from '../SpriteDataList.js';
 'use strict';
 
-class Bomb extends AssetActor {
+export default class Bomb extends AssetActor {
     constructor(context, nlayer, x, y, width, explotes) {
         super(context, nlayer, x, y, width, width * 2, false, SPRITES[CONS.sprites.BOMB]);
         this._explotes = explotes;

--- a/scripts/custom/game001/bullet.js
+++ b/scripts/custom/game001/bullet.js
@@ -1,6 +1,9 @@
+
+import Player from '../../core/actor/player.js';
+import { CONS } from '../../core/constants.js';
 'use strict';
 
-class Bullet extends Player {
+export default class Bullet extends Player {
     constructor(context, nlayer, x, y, width, direction, speed, collides) {
         super(context, nlayer, -1, x + 0.25 * width, y + 0.25 * width, width * 0.5, width * 0.5, true, false, speed);
 

--- a/scripts/custom/game001/enemyBear.js
+++ b/scripts/custom/game001/enemyBear.js
@@ -1,6 +1,11 @@
+
+import Player from '../../core/actor/player.js';
+import { CONS } from '../../core/constants.js';
+import { SPRITES } from '../SpriteDataList.js';
+import { LOGGER } from '../../core/logger.js';
 'use strict';
 
-class EnemyBear extends Player {
+export default class EnemyBear extends Player {
     constructor(context, nlayer, x, y, width, speed) {
         super(context, nlayer, -1, x, y, width, width, true, SPRITES[CONS.sprites.RAICHU], speed);
         LOGGER.debug(`Oso ubicado en posicion ${x},${y}`);

--- a/scripts/custom/game001/gameMenu.js
+++ b/scripts/custom/game001/gameMenu.js
@@ -1,4 +1,4 @@
-var mainMenuConfig = {
+export const mainMenuConfig = {
     items: [
         {label: 'Single Player', newStatus: CONS.status.GAME_SINGLE},
         {label: 'Multiplayer', newStatus: CONS.status.GAME_MULTI},

--- a/scripts/custom/game001/gamePlayer.js
+++ b/scripts/custom/game001/gamePlayer.js
@@ -1,6 +1,12 @@
+
+import Player from '../../core/actor/player.js';
+import { CONFIG } from '../../core/configuration.js';
+import { CONS } from '../../core/constants.js';
+import Bomb from './bomb.js';
+import Bullet from './bullet.js';
 'use strict';
 
-class GamePlayer extends Player {
+export default class GamePlayer extends Player {
     constructor(context, numPlayer, x, y, width, height, collides, spriteData, speed) {
         super(context, 1, numPlayer, x, y, width, height, collides, spriteData, speed);
 

--- a/scripts/custom/game001/gameRenderingView.js
+++ b/scripts/custom/game001/gameRenderingView.js
@@ -1,6 +1,8 @@
+
+import RenderingView from '../../core/manager/ingame/renderingView.js';
 'use strict';
 
-class GameRenderingView extends RenderingView {
+export default class GameRenderingView extends RenderingView {
     constructor(statusManager, scenarioDefinition, actor, x, y, width, height, drawableActors) {
         super(statusManager, scenarioDefinition, actor, x, y, width, height, drawableActors);
         this._lastLightRadius = this._actor.lightRadius;

--- a/scripts/custom/game001/gameSM.js
+++ b/scripts/custom/game001/gameSM.js
@@ -1,6 +1,16 @@
+
+import InGame from '../../core/manager/ingame/ingame.js';
+import ScenarioDefinition from '../../core/manager/ingame/scenarioDefinition.js';
+import GameRenderingView from './gameRenderingView.js';
+import GamePlayer from './gamePlayer.js';
+import EnemyBear from './enemyBear.js';
+import { CONFIG } from '../../core/configuration.js';
+import { CONS } from '../../core/constants.js';
+import { LOGGER } from '../../core/logger.js';
+import { SPRITES } from '../SpriteDataList.js';
 'use strict';
 
-class GameSM extends InGame {
+export default class GameSM extends InGame {
     constructor(context, use_multiplayer, multiplayer_vertical, singleplayer_margin, numEnemies) {
         super(context);
 

--- a/scripts/custom/game001/main.js
+++ b/scripts/custom/game001/main.js
@@ -1,3 +1,18 @@
+
+import Game from '../../core/game.js';
+import Menu from './gameMenu.js';
+import GameSM from './gameSM.js';
+import { CONFIG } from '../../core/configuration.js';
+import { CONS } from '../../core/constants.js';
+import { mainMenuConfig } from './gameMenu.js';
+import { SC_TEST001 } from '../scenario/testScenario001.js';
+import { SC_TEST002 as LEVEL2 } from '../scenario/testScenario002.js';
+import { SC_TEST003 as LEVEL3 } from '../scenario/testScenario003.js';
+import { SC_TEST004 as LEVEL4 } from '../scenario/testScenario004.js';
+import { SC_TEST005 as LEVEL5 } from '../scenario/testScenario005.js';
+import { SC_TESTMULTIPLAYER } from '../scenario/testScenarioMultiplayer.js';
+import '../customConstants.js';
+import '../customConfig.js';
 'use strict';
 
 //CONFIGURAMOS TAMAÑO DEL CANVAS
@@ -5,12 +20,8 @@ CONFIG.SCREEN_WIDTH = 1000;
 CONFIG.SCREEN_HEIGHT = 600;
 
 // Definición de escenario a probar
-var SCENDEF = SC_TEST001;
-var LEVEL2 = SC_TEST002;
-var LEVEL3 = SC_TEST003;
-var LEVEL4 = SC_TEST004;
-var LEVEL5 = SC_TEST005;
-var SCENMULTIPLAYER = SC_TESTMULTIPLAYER;
+const SCENDEF = SC_TEST001;
+const SCENMULTIPLAYER = SC_TESTMULTIPLAYER;
 
 // Variables propias para el ejemplo
 // mostrar como multiplayer

--- a/scripts/custom/scenario/testScenario001.js
+++ b/scripts/custom/scenario/testScenario001.js
@@ -1,4 +1,4 @@
-var SC_TEST001 = {
+export const SC_TEST001 = {
 
 
     background: {

--- a/scripts/custom/scenario/testScenario002.js
+++ b/scripts/custom/scenario/testScenario002.js
@@ -1,4 +1,4 @@
-var SC_TEST002 = {
+export const SC_TEST002 = {
 
 
     background: {

--- a/scripts/custom/scenario/testScenario003.js
+++ b/scripts/custom/scenario/testScenario003.js
@@ -1,4 +1,4 @@
-var SC_TEST003 = {
+export const SC_TEST003 = {
 
 
     background: {

--- a/scripts/custom/scenario/testScenario004.js
+++ b/scripts/custom/scenario/testScenario004.js
@@ -1,4 +1,4 @@
-var SC_TEST004 = {
+export const SC_TEST004 = {
 
 
     background: {

--- a/scripts/custom/scenario/testScenario005.js
+++ b/scripts/custom/scenario/testScenario005.js
@@ -1,4 +1,4 @@
-var SC_TEST005 = {
+export const SC_TEST005 = {
 
 
     background: {

--- a/scripts/custom/scenario/testScenarioJumping001.js
+++ b/scripts/custom/scenario/testScenarioJumping001.js
@@ -1,4 +1,4 @@
-var SC_TESTJUMP001 = {
+export const SC_TESTJUMP001 = {
 
 
     background: {

--- a/scripts/custom/scenario/testScenarioMultiplayer.js
+++ b/scripts/custom/scenario/testScenarioMultiplayer.js
@@ -1,4 +1,4 @@
-var SC_TESTMULTIPLAYER = {
+export const SC_TESTMULTIPLAYER = {
 
 
     background: {


### PR DESCRIPTION
## Summary
- switch script tags to a single module entrypoint
- convert core engine files to ES module syntax
- update custom game code to import using modules
- expose scenario data with exports

## Testing
- `node --check scripts/core/game.js`
- `node --check scripts/custom/game001/main.js`
- `node --check scripts/core/actor/assetActor.js`
- `node --check scripts/custom/scenario/testScenario001.js`


------
https://chatgpt.com/codex/tasks/task_e_6884f0b4db54832586a0254306191843